### PR TITLE
Export createClient function from client.ts files

### DIFF
--- a/packages/schema/src/Codegen/files/client.ts
+++ b/packages/schema/src/Codegen/files/client.ts
@@ -41,9 +41,12 @@ export class ClientFile extends File {
         return json
       }
 
-      export const client = new Client<${
-        this.codegen.schema.queryType
-      }>(schema.${this.codegen.schema.queryType}, fetchQuery)
+      export const createClient = (queryFetcher = fetchQuery) => 
+        new Client<${
+          this.codegen.schema.queryType
+        }>(schema.${this.codegen.schema.queryType}, fetchQuery)
+
+      export const client = createClient();
 
       export const query = client.query
     `


### PR DESCRIPTION
To do SSR, we need to get a new client with a fresh cache for each page request. 

It would be nice to have a standard `createClient` function to simplify [the process of integrating with Next.js](https://github.com/zenflow/next-with-gqless-example#the-gist) (or any SSR framework) just a little bit.